### PR TITLE
System argument added to the unique_terms function

### DIFF
--- a/cdapython.py
+++ b/cdapython.py
@@ -153,14 +153,28 @@ def columns(version=table_version, host=CDA_API_URL):
         return [list(t.values())[0] for t in api_response.result]
 
 
-def unique_terms(col_name, version=table_version, host=CDA_API_URL):
+def unique_terms(col_name, system=None, version=table_version, host=CDA_API_URL):
     with cda_client.ApiClient(
         configuration=cda_client.Configuration(host=host)
     ) as api_client:
         api_instance = cda_client.QueryApi(api_client)
-        _new_col, _unnest = _get_unnest_clause(col_name=col_name)
+        _new_col, _unnest_col = _get_unnest_clause(col_name=col_name)
 
-        query = f"SELECT DISTINCT({_new_col}) FROM `gdc-bq-sample.cda_mvp.{version}`, {','.join(_unnest)} ORDER BY {_new_col}"
+        if system:
+            _new_system, _unnest_system = _get_unnest_clause(col_name='ResearchSubject.identifier.system')
+            _unnest = _unnest_col + [item for item in _unnest_system if item not in _unnest_col]
+            _where_clause = f" WHERE {_new_system}=\"{system}\""
+        else:
+            _unnest = _unnest_col
+            _where_clause = ''
+        if _unnest:
+            _unnest_clause = f", {','.join(_unnest)}"
+        else:
+            _unnest_clause = ''
+
+        query = f"SELECT DISTINCT({_new_col}) FROM `gdc-bq-sample.cda_mvp.{version}`" \
+                f"{_unnest_clause}{_where_clause} ORDER BY {_new_col}"
+
         sys.stderr.write(f"{query}\n")
 
         # Execute boolean query


### PR DESCRIPTION
- Added system argument, e.g. ```unique_terms("ResearchSubject.primary_disease_type", system="PDC")```
- Fixed a bug caused by adding "," even if there's no nesting. Example: ```unique_terms("sex")```

@pshapiro4broad I'm not particularly happy with the (naive) way I've merged unnest clauses from the column and the system (line 165). I was wondering whether there is some tooling in the ```cda-service``` that does that?