### PR TITLE
typo in the second line of Detailed form

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ parts of a query are explicity split apart.
 from cdapython import Q, Col, Quoted
 
 q1 = Q(Col('ResearchSubject.Diagnosis.age_at_diagnosis'), '>=', 50 * 365)
-q2 = Q(Col('ResearchSubject.associated_project), '=' Quoted('TCGA-OV'))
+q2 = Q(Col('ResearchSubject.associated_project'), '=', Quoted('TCGA-OV'))
 ```
 
 


### PR DESCRIPTION
syntax error - was a single quote and comma missing.