### PR TITLE
Add support for new query APIs.

### DIFF
--- a/cdapython.py
+++ b/cdapython.py
@@ -101,7 +101,6 @@ class Result:
     def __str__(self) -> str:
         return f"""
 Query: {self.sql}
-Offset: {self._offset}
 Count: {self.count}
 Total Row Count: {self.total_row_count}
 More pages: {self.has_next_page}

--- a/cdapython.py
+++ b/cdapython.py
@@ -101,6 +101,7 @@ class Result:
     def __str__(self) -> str:
         return f"""
 Query: {self.sql}
+Offset: {self._offset}
 Count: {self.count}
 Total Row Count: {self.total_row_count}
 More pages: {self.has_next_page}

--- a/cdapython.py
+++ b/cdapython.py
@@ -3,8 +3,10 @@ import sys
 from typing import Union
 
 import cda_client
+from cda_client.api.query_api import QueryApi
+from cda_client.model.query import Query
 
-__version__ = "2021.3.11"
+__version__ = "2021.5.14"
 
 CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
 table_version = "v3"
@@ -12,33 +14,38 @@ table_version = "v3"
 pp = pprint.PrettyPrinter(indent=2)
 
 
-def Col(col_name) -> cda_client.Query:
-    return cda_client.Query(node_type="column", value=col_name)
+# these methods may be better expressed as subclasses of Query
+def Col(col_name) -> Query:
+    return Query(node_type="column", value=col_name)
 
 
-def Quoted(quoted_val) -> cda_client.Query:
-    return cda_client.Query(node_type="quoted", value=quoted_val)
+def Quoted(quoted_val) -> Query:
+    return Query(node_type="quoted", value=quoted_val)
 
 
-def Unquoted(val) -> cda_client.Query:
-    return cda_client.Query(node_type="unquoted", value=val)
+def Unquoted(val) -> Query:
+    return Query(node_type="unquoted", value=val)
 
 
-def infer_quote(val: Union[int, float, str, "Q", cda_client.Query]) -> cda_client.Query:
-    if isinstance(val, (Q, cda_client.Query)):
+def infer_quote(val: Union[int, float, str, "Q", Query]) -> Query:
+    if isinstance(val, (Q, Query)):
         return val
-    elif isinstance(val, str):
-        if val.startswith('"') and val.endswith('"'):
-            return Quoted(val[1:-1])
-        else:
-            return Unquoted(val)
+    elif isinstance(val, str) and val.startswith('"') and val.endswith('"'):
+        return Quoted(val[1:-1])
     else:
         return Unquoted(val)
 
 
+def get_query_result(api_instance, query_id, offset, page_size):
+    while True:
+        response = api_instance.query(id=query_id, offset=offset, page_size=page_size)
+        if response.total_row_count is not None:
+            return Result(response, query_id, offset, page_size, api_instance)
+
+
 class Q:
     def __init__(self, *args) -> None:
-        self.query = cda_client.Query()
+        self.query = Query()
 
         if len(args) == 1:
             _l, _op, _r = args[0].split(" ", 2)
@@ -57,20 +64,21 @@ class Q:
         self.query.l = _l
         self.query.r = _r
 
-    def run(self, offset=0, limit=1000, version=table_version, host=CDA_API_URL, dry_run=False):
+    def run(self, offset=0, limit=1000000, page_size=1000, version=table_version, host=CDA_API_URL, dry_run=False):
         with cda_client.ApiClient(
-            configuration=cda_client.Configuration(host=host)
+                configuration=cda_client.Configuration(host=host)
         ) as api_client:
-            api_instance = cda_client.QueryApi(api_client)
-            query = self.query  # Query | The boolean query
-            offset = offset  # int | The number of entries to skip (optional)
-            limit = limit  # int | The numbers of entries to return (optional)
+            api_instance = QueryApi(api_client)
+            # The boolean query
+            query = self.query
+            # If present, the maximum of size of the query's results
+            limit = limit
 
             # Execute boolean query
-            api_response = api_instance.boolean_query(
-                version, query, offset=offset, limit=limit, dry_run=dry_run
-            )
-            return Result(api_response, offset, limit, version, host)
+            api_response = api_instance.boolean_query(query, version=version, limit=limit, dry_run=dry_run)
+            if dry_run is True:
+                return api_response
+            return get_query_result(api_instance, api_response.query_id, offset, page_size)
 
     def And(self, right: "Q"):
         return Q(self.query, "AND", right.query)
@@ -88,20 +96,19 @@ class Q:
 class Result:
     """A convenient wrapper around the response object from the CDA service."""
 
-    def __init__(self, api_response, offset, limit, version, host) -> None:
+    def __init__(self, api_response, query_id, offset, page_size, api_instance) -> None:
         self._api_response = api_response
+        self._query_id = query_id
         self._offset = offset
-        self._limit = limit
-        self._version = version
-        self._host = host
+        self._page_size = page_size
+        self._api_instance = api_instance
 
     def __str__(self) -> str:
         return f"""
-Query: {self._api_response.query_sql}
-Offset: {self._offset}
-Limit: {self._limit}
+Query: {self.sql}
 Count: {self.count}
-More pages: {"No" if self.count < self._limit else "Yes"}
+Total Row Count: {self.total_row_count}
+More pages: {self.has_next_page}
 """
 
     @property
@@ -112,57 +119,58 @@ More pages: {"No" if self.count < self._limit else "Yes"}
     def count(self):
         return len(self._api_response.result)
 
+    @property
+    def total_row_count(self):
+        return self._api_response.total_row_count
+
+    @property
+    def has_next_page(self):
+        return (self._offset + self._page_size) <= self.total_row_count
+
     def __getitem__(self, idx):
         return self._api_response.result[idx]
 
     def pretty_print(self, idx):
         pp.pprint(self[idx])
 
-    def next_page(self, limit=None):
-        if self.count < self._limit:
+    def next_page(self, page_size=None):
+        if not self.has_next_page:
             raise StopIteration
 
-        _offset = self._offset + self._limit
-        _limit = limit or self._limit
-        return self._get_result(_offset, _limit)
-        
-    def prev_page(self, limit=None):
-        _offset = self._offset - self._limit
-        _offset = max(0, _offset)
-        _limit = limit or self._limit
-        return self._get_result(_offset, _limit)
+        _offset = self._offset + self._page_size
+        _page_size = page_size or self._page_size
+        return self._get_result(_offset, _page_size)
 
-    def _get_result(self, _offset, _limit):
-        with cda_client.ApiClient(
-            configuration=cda_client.Configuration(host=self._host)
-        ) as api_client:
-            api_instance = cda_client.QueryApi(api_client)
-            api_response = api_instance.sql_query(
-                self._version, self._api_response.query_sql, offset=_offset, limit=_limit
-            )
-            return Result(api_response, _offset, _limit, version=self._version, host=self._host)
+    def prev_page(self, page_size=None):
+        _offset = self._offset - self._page_size
+        _offset = max(0, _offset)
+        _page_size = page_size or self._page_size
+        return self._get_result(_offset, _page_size)
+
+    def _get_result(self, _offset, _page_size):
+        return get_query_result(self._api_instance, self._query_id, _offset, _page_size)
 
 
 def columns(version=table_version, host=CDA_API_URL):
     """Get columns names from the database."""
     query = f"SELECT field_path FROM `gdc-bq-sample.cda_mvp.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name = '{version}'"
     sys.stderr.write(f"{query}\n")
-    # Execute boolean query
+    # Execute query
     with cda_client.ApiClient(
-        configuration=cda_client.Configuration(host=host)
+            configuration=cda_client.Configuration(host=host)
     ) as api_client:
-        api_instance = cda_client.QueryApi(api_client)
-        api_response = api_instance.sql_query(
-            version, query, offset=0, limit=10000
-        )
-        return [list(t.values())[0] for t in api_response.result]
+        api_instance = QueryApi(api_client)
+        limit = 1000
+        api_response = api_instance.sql_query(query, version=version, limit=limit)
+        query_result = get_query_result(api_instance, api_response.query_id, 0, limit)
+        return [list(t.values())[0] for t in query_result]
 
 
 def unique_terms(col_name, system=None, version=table_version, host=CDA_API_URL):
     with cda_client.ApiClient(
-        configuration=cda_client.Configuration(host=host)
+            configuration=cda_client.Configuration(host=host)
     ) as api_client:
-        api_instance = cda_client.QueryApi(api_client)
+        api_instance = QueryApi(api_client)
         _new_col, _unnest_col = _get_unnest_clause(col_name=col_name)
 
         if system:
@@ -182,11 +190,11 @@ def unique_terms(col_name, system=None, version=table_version, host=CDA_API_URL)
 
         sys.stderr.write(f"{query}\n")
 
-        # Execute boolean query
-        api_response = api_instance.sql_query(
-            version, query, offset=0, limit=10000
-        )
-        return [list(t.values())[0] for t in api_response.result]
+        # Execute query
+        limit = 1000
+        api_response = api_instance.sql_query(query, version=version, limit=limit)
+        query_result = get_query_result(api_instance, api_response.query_id, 0, limit)
+        return [list(t.values())[0] for t in query_result]
 
 
 # column ->
@@ -204,6 +212,6 @@ def _get_unnest_clause(col_name):
         _new_col = f"_{c[-2]}.{c[-1]}"
         _unnest = [f"UNNEST({c[0]}) AS _{c[0]}"]
         for n in range(1, len(c) - 1):
-            _unnest += [f"UNNEST(_{c[n-1]}.{c[n]}) AS _{c[n]}"]
-        
-    return (_new_col, _unnest)
+            _unnest += [f"UNNEST(_{c[n - 1]}.{c[n]}) AS _{c[n]}"]
+
+    return _new_col, _unnest

--- a/example.ipynb
+++ b/example.ipynb
@@ -60,7 +60,58 @@
     },
     {
      "data": {
-      "text/plain": "['days_to_birth',\n 'race',\n 'sex',\n 'ethnicity',\n 'id',\n 'ResearchSubject',\n 'ResearchSubject.Diagnosis',\n 'ResearchSubject.Diagnosis.morphology',\n 'ResearchSubject.Diagnosis.tumor_stage',\n 'ResearchSubject.Diagnosis.tumor_grade',\n 'ResearchSubject.Diagnosis.Treatment',\n 'ResearchSubject.Diagnosis.Treatment.type',\n 'ResearchSubject.Diagnosis.Treatment.outcome',\n 'ResearchSubject.Diagnosis.id',\n 'ResearchSubject.Diagnosis.primary_diagnosis',\n 'ResearchSubject.Diagnosis.age_at_diagnosis',\n 'ResearchSubject.Specimen',\n 'ResearchSubject.Specimen.File',\n 'ResearchSubject.Specimen.File.label',\n 'ResearchSubject.Specimen.File.associated_project',\n 'ResearchSubject.Specimen.File.drs_uri',\n 'ResearchSubject.Specimen.File.identifier',\n 'ResearchSubject.Specimen.File.identifier.system',\n 'ResearchSubject.Specimen.File.identifier.value',\n 'ResearchSubject.Specimen.File.data_category',\n 'ResearchSubject.Specimen.File.byte_size',\n 'ResearchSubject.Specimen.File.type',\n 'ResearchSubject.Specimen.File.file_format',\n 'ResearchSubject.Specimen.File.checksum',\n 'ResearchSubject.Specimen.File.id',\n 'ResearchSubject.Specimen.File.data_type',\n 'ResearchSubject.Specimen.derived_from_specimen',\n 'ResearchSubject.Specimen.associated_project',\n 'ResearchSubject.Specimen.age_at_collection',\n 'ResearchSubject.Specimen.anatomical_site',\n 'ResearchSubject.Specimen.source_material_type',\n 'ResearchSubject.Specimen.derived_from_subject',\n 'ResearchSubject.Specimen.specimen_type',\n 'ResearchSubject.Specimen.id',\n 'ResearchSubject.Specimen.primary_disease_type',\n 'ResearchSubject.Specimen.identifier',\n 'ResearchSubject.Specimen.identifier.system',\n 'ResearchSubject.Specimen.identifier.value',\n 'ResearchSubject.associated_project',\n 'ResearchSubject.id',\n 'ResearchSubject.primary_disease_type',\n 'ResearchSubject.identifier',\n 'ResearchSubject.identifier.system',\n 'ResearchSubject.identifier.value',\n 'ResearchSubject.primary_disease_site']"
+      "text/plain": [
+       "['days_to_birth',\n",
+       " 'race',\n",
+       " 'sex',\n",
+       " 'ethnicity',\n",
+       " 'id',\n",
+       " 'ResearchSubject',\n",
+       " 'ResearchSubject.Diagnosis',\n",
+       " 'ResearchSubject.Diagnosis.morphology',\n",
+       " 'ResearchSubject.Diagnosis.tumor_stage',\n",
+       " 'ResearchSubject.Diagnosis.tumor_grade',\n",
+       " 'ResearchSubject.Diagnosis.Treatment',\n",
+       " 'ResearchSubject.Diagnosis.Treatment.type',\n",
+       " 'ResearchSubject.Diagnosis.Treatment.outcome',\n",
+       " 'ResearchSubject.Diagnosis.id',\n",
+       " 'ResearchSubject.Diagnosis.primary_diagnosis',\n",
+       " 'ResearchSubject.Diagnosis.age_at_diagnosis',\n",
+       " 'ResearchSubject.Specimen',\n",
+       " 'ResearchSubject.Specimen.File',\n",
+       " 'ResearchSubject.Specimen.File.label',\n",
+       " 'ResearchSubject.Specimen.File.associated_project',\n",
+       " 'ResearchSubject.Specimen.File.drs_uri',\n",
+       " 'ResearchSubject.Specimen.File.identifier',\n",
+       " 'ResearchSubject.Specimen.File.identifier.system',\n",
+       " 'ResearchSubject.Specimen.File.identifier.value',\n",
+       " 'ResearchSubject.Specimen.File.data_category',\n",
+       " 'ResearchSubject.Specimen.File.byte_size',\n",
+       " 'ResearchSubject.Specimen.File.type',\n",
+       " 'ResearchSubject.Specimen.File.file_format',\n",
+       " 'ResearchSubject.Specimen.File.checksum',\n",
+       " 'ResearchSubject.Specimen.File.id',\n",
+       " 'ResearchSubject.Specimen.File.data_type',\n",
+       " 'ResearchSubject.Specimen.derived_from_specimen',\n",
+       " 'ResearchSubject.Specimen.associated_project',\n",
+       " 'ResearchSubject.Specimen.age_at_collection',\n",
+       " 'ResearchSubject.Specimen.anatomical_site',\n",
+       " 'ResearchSubject.Specimen.source_material_type',\n",
+       " 'ResearchSubject.Specimen.derived_from_subject',\n",
+       " 'ResearchSubject.Specimen.specimen_type',\n",
+       " 'ResearchSubject.Specimen.id',\n",
+       " 'ResearchSubject.Specimen.primary_disease_type',\n",
+       " 'ResearchSubject.Specimen.identifier',\n",
+       " 'ResearchSubject.Specimen.identifier.system',\n",
+       " 'ResearchSubject.Specimen.identifier.value',\n",
+       " 'ResearchSubject.associated_project',\n",
+       " 'ResearchSubject.id',\n",
+       " 'ResearchSubject.primary_disease_type',\n",
+       " 'ResearchSubject.identifier',\n",
+       " 'ResearchSubject.identifier.system',\n",
+       " 'ResearchSubject.identifier.value',\n",
+       " 'ResearchSubject.primary_disease_site']"
+      ]
      },
      "execution_count": 2,
      "metadata": {},
@@ -102,7 +153,46 @@
     },
     {
      "data": {
-      "text/plain": "['Additional - New Primary',\n 'Additional Metastatic',\n 'Blood Derived Cancer - Bone Marrow',\n 'Blood Derived Cancer - Bone Marrow, Post-treatment',\n 'Blood Derived Cancer - Peripheral Blood',\n 'Blood Derived Cancer - Peripheral Blood, Post-treatment',\n 'Blood Derived Normal',\n 'Bone Marrow Normal',\n 'Buccal Cell Normal',\n 'Cell Lines',\n 'Control Analyte',\n 'DNA',\n 'Expanded Next Generation Cancer Model',\n 'FFPE Scrolls',\n 'Fibroblasts from Bone Marrow Normal',\n 'Granulocytes',\n 'Lymphoid Normal',\n 'Metastatic',\n 'Mononuclear Cells from Bone Marrow Normal',\n 'Neoplasms of Uncertain and Unknown Behavior',\n 'Next Generation Cancer Model',\n 'Normal',\n 'Normal Adjacent Tissue',\n 'Not Reported',\n 'Post neo-adjuvant therapy',\n 'Primary Blood Derived Cancer - Bone Marrow',\n 'Primary Blood Derived Cancer - Peripheral Blood',\n 'Primary Tumor',\n 'Primary Xenograft Tissue',\n 'Recurrent Blood Derived Cancer - Bone Marrow',\n 'Recurrent Blood Derived Cancer - Peripheral Blood',\n 'Recurrent Tumor',\n 'Slides',\n 'Solid Tissue Normal',\n 'Tumor',\n 'Unknown',\n 'Xenograft',\n 'Xenograft Tissue']"
+      "text/plain": [
+       "['Additional - New Primary',\n",
+       " 'Additional Metastatic',\n",
+       " 'Blood Derived Cancer - Bone Marrow',\n",
+       " 'Blood Derived Cancer - Bone Marrow, Post-treatment',\n",
+       " 'Blood Derived Cancer - Peripheral Blood',\n",
+       " 'Blood Derived Cancer - Peripheral Blood, Post-treatment',\n",
+       " 'Blood Derived Normal',\n",
+       " 'Bone Marrow Normal',\n",
+       " 'Buccal Cell Normal',\n",
+       " 'Cell Lines',\n",
+       " 'Control Analyte',\n",
+       " 'DNA',\n",
+       " 'Expanded Next Generation Cancer Model',\n",
+       " 'FFPE Scrolls',\n",
+       " 'Fibroblasts from Bone Marrow Normal',\n",
+       " 'Granulocytes',\n",
+       " 'Lymphoid Normal',\n",
+       " 'Metastatic',\n",
+       " 'Mononuclear Cells from Bone Marrow Normal',\n",
+       " 'Neoplasms of Uncertain and Unknown Behavior',\n",
+       " 'Next Generation Cancer Model',\n",
+       " 'Normal',\n",
+       " 'Normal Adjacent Tissue',\n",
+       " 'Not Reported',\n",
+       " 'Post neo-adjuvant therapy',\n",
+       " 'Primary Blood Derived Cancer - Bone Marrow',\n",
+       " 'Primary Blood Derived Cancer - Peripheral Blood',\n",
+       " 'Primary Tumor',\n",
+       " 'Primary Xenograft Tissue',\n",
+       " 'Recurrent Blood Derived Cancer - Bone Marrow',\n",
+       " 'Recurrent Blood Derived Cancer - Peripheral Blood',\n",
+       " 'Recurrent Tumor',\n",
+       " 'Slides',\n",
+       " 'Solid Tissue Normal',\n",
+       " 'Tumor',\n",
+       " 'Unknown',\n",
+       " 'Xenograft',\n",
+       " 'Xenograft Tissue']"
+      ]
      },
      "execution_count": 3,
      "metadata": {},
@@ -136,7 +226,17 @@
     },
     {
      "data": {
-      "text/plain": "['Cell Lines',\n 'Normal',\n 'Normal Adjacent Tissue',\n 'Not Reported',\n 'Primary Tumor',\n 'Solid Tissue Normal',\n 'Tumor',\n 'Xenograft',\n 'Xenograft Tissue']"
+      "text/plain": [
+       "['Cell Lines',\n",
+       " 'Normal',\n",
+       " 'Normal Adjacent Tissue',\n",
+       " 'Not Reported',\n",
+       " 'Primary Tumor',\n",
+       " 'Solid Tissue Normal',\n",
+       " 'Tumor',\n",
+       " 'Xenograft',\n",
+       " 'Xenograft Tissue']"
+      ]
      },
      "execution_count": 4,
      "metadata": {},
@@ -168,10 +268,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3 WHERE (v3.id = 'TCGA-E2-A10A')\n",
+      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3 WHERE (v3.id = 'TCGA-E2-A10A')\n",
+      "Offset: 0\n",
+      "Limit: 1000\n",
       "Count: 1\n",
-      "Total Row Count: 1\n",
-      "More pages: False\n",
+      "More pages: No\n",
       "\n"
      ]
     }
@@ -286,10 +387,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Diagnosis.age_at_diagnosis > 50*365) AND (_ResearchSubject.associated_project = 'TCGA-OV'))\n",
+      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Diagnosis.age_at_diagnosis > 50*365) AND (_ResearchSubject.associated_project = 'TCGA-OV'))\n",
+      "Offset: 0\n",
+      "Limit: 1000\n",
       "Count: 461\n",
-      "Total Row Count: 461\n",
-      "More pages: False\n",
+      "More pages: No\n",
       "\n"
      ]
     }
@@ -325,10 +427,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND (_Diagnosis.age_at_diagnosis < 30*365))\n",
+      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND (_Diagnosis.age_at_diagnosis < 30*365))\n",
+      "Offset: 0\n",
+      "Limit: 1000\n",
       "Count: 647\n",
-      "Total Row Count: 647\n",
-      "More pages: False\n",
+      "More pages: No\n",
       "\n"
      ]
     }
@@ -362,10 +465,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis, UNNEST(_Specimen.identifier) AS _identifier WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND ((_Diagnosis.age_at_diagnosis < 30*365) AND (_identifier.system = 'GDC')))\n",
+      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis, UNNEST(_Specimen.identifier) AS _identifier WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND ((_Diagnosis.age_at_diagnosis < 30*365) AND (_identifier.system = 'GDC')))\n",
+      "Offset: 0\n",
+      "Limit: 1000\n",
       "Count: 647\n",
-      "Total Row Count: 647\n",
-      "More pages: False\n",
+      "More pages: No\n",
       "\n"
      ]
     }
@@ -401,7 +505,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'FM-AD', 'TCGA-SKCM', 'TCGA-UVM'}\n"
+      "{'TCGA-UVM', 'TCGA-SKCM', 'FM-AD'}\n"
      ]
     }
    ],
@@ -449,10 +553,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
-      "Count: 10\n",
-      "Total Row Count: 27284\n",
-      "More pages: True\n",
+      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
+      "Offset: 0\n",
+      "Limit: 1000\n",
+      "Count: 1000\n",
+      "More pages: Yes\n",
       "\n"
      ]
     }
@@ -468,7 +573,7 @@
     "q2 = disease1.Or(disease2)\n",
     "q = q1.And(q2)\n",
     "\n",
-    "r = q.run(limit=10)\n",
+    "r = q.run()\n",
     "print(r)"
    ]
   },
@@ -477,7 +582,7 @@
    "id": "marine-failing",
    "metadata": {},
    "source": [
-    "In this case, we have a result that contains more than 1000 records which is the default page size. To load the next 1000 records, we can use the ```next_page()``` method:"
+    "In this case, we have a result that contains more than 1000 records which is the limit for a single page. To load the next 1000 records, we can use the ```next_page()``` method:"
    ]
   },
   {
@@ -501,10 +606,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
-      "Count: 10\n",
-      "Total Row Count: 27284\n",
-      "More pages: True\n",
+      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
+      "Offset: 1000\n",
+      "Limit: 1000\n",
+      "Count: 1000\n",
+      "More pages: Yes\n",
       "\n"
      ]
     }
@@ -560,7 +666,67 @@
     },
     {
      "data": {
-      "text/plain": "[None,\n 'Acinar Cell Neoplasms',\n 'Adenomas and Adenocarcinomas',\n 'Adnexal and Skin Appendage Neoplasms',\n 'Basal Cell Neoplasms',\n 'Blood Vessel Tumors',\n 'Chronic Myeloproliferative Disorders',\n 'Complex Epithelial Neoplasms',\n 'Complex Mixed and Stromal Neoplasms',\n 'Cystic, Mucinous and Serous Neoplasms',\n 'Ductal and Lobular Neoplasms',\n 'Epithelial Neoplasms, NOS',\n 'Fibroepithelial Neoplasms',\n 'Fibromatous Neoplasms',\n 'Germ Cell Neoplasms',\n 'Giant Cell Tumors',\n 'Gliomas',\n 'Granular Cell Tumors and Alveolar Soft Part Sarcomas',\n 'Hodgkin Lymphoma',\n 'Immunoproliferative Diseases',\n 'Leukemias, NOS',\n 'Lipomatous Neoplasms',\n 'Lymphatic Vessel Tumors',\n 'Lymphoid Leukemias',\n 'Malignant Lymphomas, NOS or Diffuse',\n 'Mast Cell Tumors',\n 'Mature B-Cell Lymphomas',\n 'Mature T- and NK-Cell Lymphomas',\n 'Meningiomas',\n 'Mesonephromas',\n 'Mesothelial Neoplasms',\n 'Miscellaneous Bone Tumors',\n 'Miscellaneous Tumors',\n 'Mucoepidermoid Neoplasms',\n 'Myelodysplastic Syndromes',\n 'Myeloid Leukemias',\n 'Myomatous Neoplasms',\n 'Myxomatous Neoplasms',\n 'Neoplasms of Histiocytes and Accessory Lymphoid Cells',\n 'Neoplasms, NOS',\n 'Nerve Sheath Tumors',\n 'Neuroepitheliomatous Neoplasms',\n 'Nevi and Melanomas',\n 'Not Applicable',\n 'Not Reported',\n 'Odontogenic Tumors',\n 'Osseous and Chondromatous Neoplasms',\n 'Other Leukemias',\n 'Paragangliomas and Glomus Tumors',\n 'Plasma Cell Tumors',\n 'Precursor Cell Lymphoblastic Lymphoma',\n 'Soft Tissue Tumors and Sarcomas, NOS',\n 'Specialized Gonadal Neoplasms',\n 'Squamous Cell Neoplasms',\n 'Synovial-like Neoplasms',\n 'Thymic Epithelial Neoplasms',\n 'Transitional Cell Papillomas and Carcinomas',\n 'Trophoblastic neoplasms',\n 'Unknown']"
+      "text/plain": [
+       "[None,\n",
+       " 'Acinar Cell Neoplasms',\n",
+       " 'Adenomas and Adenocarcinomas',\n",
+       " 'Adnexal and Skin Appendage Neoplasms',\n",
+       " 'Basal Cell Neoplasms',\n",
+       " 'Blood Vessel Tumors',\n",
+       " 'Chronic Myeloproliferative Disorders',\n",
+       " 'Complex Epithelial Neoplasms',\n",
+       " 'Complex Mixed and Stromal Neoplasms',\n",
+       " 'Cystic, Mucinous and Serous Neoplasms',\n",
+       " 'Ductal and Lobular Neoplasms',\n",
+       " 'Epithelial Neoplasms, NOS',\n",
+       " 'Fibroepithelial Neoplasms',\n",
+       " 'Fibromatous Neoplasms',\n",
+       " 'Germ Cell Neoplasms',\n",
+       " 'Giant Cell Tumors',\n",
+       " 'Gliomas',\n",
+       " 'Granular Cell Tumors and Alveolar Soft Part Sarcomas',\n",
+       " 'Hodgkin Lymphoma',\n",
+       " 'Immunoproliferative Diseases',\n",
+       " 'Leukemias, NOS',\n",
+       " 'Lipomatous Neoplasms',\n",
+       " 'Lymphatic Vessel Tumors',\n",
+       " 'Lymphoid Leukemias',\n",
+       " 'Malignant Lymphomas, NOS or Diffuse',\n",
+       " 'Mast Cell Tumors',\n",
+       " 'Mature B-Cell Lymphomas',\n",
+       " 'Mature T- and NK-Cell Lymphomas',\n",
+       " 'Meningiomas',\n",
+       " 'Mesonephromas',\n",
+       " 'Mesothelial Neoplasms',\n",
+       " 'Miscellaneous Bone Tumors',\n",
+       " 'Miscellaneous Tumors',\n",
+       " 'Mucoepidermoid Neoplasms',\n",
+       " 'Myelodysplastic Syndromes',\n",
+       " 'Myeloid Leukemias',\n",
+       " 'Myomatous Neoplasms',\n",
+       " 'Myxomatous Neoplasms',\n",
+       " 'Neoplasms of Histiocytes and Accessory Lymphoid Cells',\n",
+       " 'Neoplasms, NOS',\n",
+       " 'Nerve Sheath Tumors',\n",
+       " 'Neuroepitheliomatous Neoplasms',\n",
+       " 'Nevi and Melanomas',\n",
+       " 'Not Applicable',\n",
+       " 'Not Reported',\n",
+       " 'Odontogenic Tumors',\n",
+       " 'Osseous and Chondromatous Neoplasms',\n",
+       " 'Other Leukemias',\n",
+       " 'Paragangliomas and Glomus Tumors',\n",
+       " 'Plasma Cell Tumors',\n",
+       " 'Precursor Cell Lymphoblastic Lymphoma',\n",
+       " 'Soft Tissue Tumors and Sarcomas, NOS',\n",
+       " 'Specialized Gonadal Neoplasms',\n",
+       " 'Squamous Cell Neoplasms',\n",
+       " 'Synovial-like Neoplasms',\n",
+       " 'Thymic Epithelial Neoplasms',\n",
+       " 'Transitional Cell Papillomas and Carcinomas',\n",
+       " 'Trophoblastic neoplasms',\n",
+       " 'Unknown']"
+      ]
      },
      "execution_count": 15,
      "metadata": {},
@@ -594,7 +760,26 @@
     },
     {
      "data": {
-      "text/plain": "['Breast Invasive Carcinoma',\n 'Chromophobe Renal Cell Carcinoma',\n 'Clear Cell Renal Cell Carcinoma',\n 'Colon Adenocarcinoma',\n 'Early Onset Gastric Cancer',\n 'Glioblastoma',\n 'Head and Neck Squamous Cell Carcinoma',\n 'Hepatocellular Carcinoma ',\n 'Lung Adenocarcinoma',\n 'Lung Squamous Cell Carcinoma',\n 'Oral Squamous Cell Carcinoma',\n 'Other',\n 'Ovarian Serous Cystadenocarcinoma',\n 'Pancreatic Ductal Adenocarcinoma',\n 'Papillary Renal Cell Carcinoma',\n 'Pediatric/AYA Brain Tumors',\n 'Rectum Adenocarcinoma',\n 'Uterine Corpus Endometrial Carcinoma']"
+      "text/plain": [
+       "['Breast Invasive Carcinoma',\n",
+       " 'Chromophobe Renal Cell Carcinoma',\n",
+       " 'Clear Cell Renal Cell Carcinoma',\n",
+       " 'Colon Adenocarcinoma',\n",
+       " 'Early Onset Gastric Cancer',\n",
+       " 'Glioblastoma',\n",
+       " 'Head and Neck Squamous Cell Carcinoma',\n",
+       " 'Hepatocellular Carcinoma ',\n",
+       " 'Lung Adenocarcinoma',\n",
+       " 'Lung Squamous Cell Carcinoma',\n",
+       " 'Oral Squamous Cell Carcinoma',\n",
+       " 'Other',\n",
+       " 'Ovarian Serous Cystadenocarcinoma',\n",
+       " 'Pancreatic Ductal Adenocarcinoma',\n",
+       " 'Papillary Renal Cell Carcinoma',\n",
+       " 'Pediatric/AYA Brain Tumors',\n",
+       " 'Rectum Adenocarcinoma',\n",
+       " 'Uterine Corpus Endometrial Carcinoma']"
+      ]
      },
      "execution_count": 16,
      "metadata": {},
@@ -624,10 +809,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT v3.* FROM (SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE ((_ResearchSubject.primary_disease_type = 'Ovarian Serous Cystadenocarcinoma') AND (_identifier.system = 'PDC'))) AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE (_identifier.system = 'GDC')\n",
+      "Query: SELECT * FROM (SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE ((_ResearchSubject.primary_disease_type = 'Ovarian Serous Cystadenocarcinoma') AND (_identifier.system = 'PDC'))), UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE (_identifier.system = 'GDC')\n",
+      "Offset: 0\n",
+      "Limit: 1000\n",
       "Count: 275\n",
-      "Total Row Count: 275\n",
-      "More pages: False\n",
+      "More pages: No\n",
       "\n"
      ]
     }

--- a/example.ipynb
+++ b/example.ipynb
@@ -60,58 +60,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['days_to_birth',\n",
-       " 'race',\n",
-       " 'sex',\n",
-       " 'ethnicity',\n",
-       " 'id',\n",
-       " 'ResearchSubject',\n",
-       " 'ResearchSubject.Diagnosis',\n",
-       " 'ResearchSubject.Diagnosis.morphology',\n",
-       " 'ResearchSubject.Diagnosis.tumor_stage',\n",
-       " 'ResearchSubject.Diagnosis.tumor_grade',\n",
-       " 'ResearchSubject.Diagnosis.Treatment',\n",
-       " 'ResearchSubject.Diagnosis.Treatment.type',\n",
-       " 'ResearchSubject.Diagnosis.Treatment.outcome',\n",
-       " 'ResearchSubject.Diagnosis.id',\n",
-       " 'ResearchSubject.Diagnosis.primary_diagnosis',\n",
-       " 'ResearchSubject.Diagnosis.age_at_diagnosis',\n",
-       " 'ResearchSubject.Specimen',\n",
-       " 'ResearchSubject.Specimen.File',\n",
-       " 'ResearchSubject.Specimen.File.label',\n",
-       " 'ResearchSubject.Specimen.File.associated_project',\n",
-       " 'ResearchSubject.Specimen.File.drs_uri',\n",
-       " 'ResearchSubject.Specimen.File.identifier',\n",
-       " 'ResearchSubject.Specimen.File.identifier.system',\n",
-       " 'ResearchSubject.Specimen.File.identifier.value',\n",
-       " 'ResearchSubject.Specimen.File.data_category',\n",
-       " 'ResearchSubject.Specimen.File.byte_size',\n",
-       " 'ResearchSubject.Specimen.File.type',\n",
-       " 'ResearchSubject.Specimen.File.file_format',\n",
-       " 'ResearchSubject.Specimen.File.checksum',\n",
-       " 'ResearchSubject.Specimen.File.id',\n",
-       " 'ResearchSubject.Specimen.File.data_type',\n",
-       " 'ResearchSubject.Specimen.derived_from_specimen',\n",
-       " 'ResearchSubject.Specimen.associated_project',\n",
-       " 'ResearchSubject.Specimen.age_at_collection',\n",
-       " 'ResearchSubject.Specimen.anatomical_site',\n",
-       " 'ResearchSubject.Specimen.source_material_type',\n",
-       " 'ResearchSubject.Specimen.derived_from_subject',\n",
-       " 'ResearchSubject.Specimen.specimen_type',\n",
-       " 'ResearchSubject.Specimen.id',\n",
-       " 'ResearchSubject.Specimen.primary_disease_type',\n",
-       " 'ResearchSubject.Specimen.identifier',\n",
-       " 'ResearchSubject.Specimen.identifier.system',\n",
-       " 'ResearchSubject.Specimen.identifier.value',\n",
-       " 'ResearchSubject.associated_project',\n",
-       " 'ResearchSubject.id',\n",
-       " 'ResearchSubject.primary_disease_type',\n",
-       " 'ResearchSubject.identifier',\n",
-       " 'ResearchSubject.identifier.system',\n",
-       " 'ResearchSubject.identifier.value',\n",
-       " 'ResearchSubject.primary_disease_site']"
-      ]
+      "text/plain": "['days_to_birth',\n 'race',\n 'sex',\n 'ethnicity',\n 'id',\n 'ResearchSubject',\n 'ResearchSubject.Diagnosis',\n 'ResearchSubject.Diagnosis.morphology',\n 'ResearchSubject.Diagnosis.tumor_stage',\n 'ResearchSubject.Diagnosis.tumor_grade',\n 'ResearchSubject.Diagnosis.Treatment',\n 'ResearchSubject.Diagnosis.Treatment.type',\n 'ResearchSubject.Diagnosis.Treatment.outcome',\n 'ResearchSubject.Diagnosis.id',\n 'ResearchSubject.Diagnosis.primary_diagnosis',\n 'ResearchSubject.Diagnosis.age_at_diagnosis',\n 'ResearchSubject.Specimen',\n 'ResearchSubject.Specimen.File',\n 'ResearchSubject.Specimen.File.label',\n 'ResearchSubject.Specimen.File.associated_project',\n 'ResearchSubject.Specimen.File.drs_uri',\n 'ResearchSubject.Specimen.File.identifier',\n 'ResearchSubject.Specimen.File.identifier.system',\n 'ResearchSubject.Specimen.File.identifier.value',\n 'ResearchSubject.Specimen.File.data_category',\n 'ResearchSubject.Specimen.File.byte_size',\n 'ResearchSubject.Specimen.File.type',\n 'ResearchSubject.Specimen.File.file_format',\n 'ResearchSubject.Specimen.File.checksum',\n 'ResearchSubject.Specimen.File.id',\n 'ResearchSubject.Specimen.File.data_type',\n 'ResearchSubject.Specimen.derived_from_specimen',\n 'ResearchSubject.Specimen.associated_project',\n 'ResearchSubject.Specimen.age_at_collection',\n 'ResearchSubject.Specimen.anatomical_site',\n 'ResearchSubject.Specimen.source_material_type',\n 'ResearchSubject.Specimen.derived_from_subject',\n 'ResearchSubject.Specimen.specimen_type',\n 'ResearchSubject.Specimen.id',\n 'ResearchSubject.Specimen.primary_disease_type',\n 'ResearchSubject.Specimen.identifier',\n 'ResearchSubject.Specimen.identifier.system',\n 'ResearchSubject.Specimen.identifier.value',\n 'ResearchSubject.associated_project',\n 'ResearchSubject.id',\n 'ResearchSubject.primary_disease_type',\n 'ResearchSubject.identifier',\n 'ResearchSubject.identifier.system',\n 'ResearchSubject.identifier.value',\n 'ResearchSubject.primary_disease_site']"
      },
      "execution_count": 2,
      "metadata": {},
@@ -153,46 +102,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['Additional - New Primary',\n",
-       " 'Additional Metastatic',\n",
-       " 'Blood Derived Cancer - Bone Marrow',\n",
-       " 'Blood Derived Cancer - Bone Marrow, Post-treatment',\n",
-       " 'Blood Derived Cancer - Peripheral Blood',\n",
-       " 'Blood Derived Cancer - Peripheral Blood, Post-treatment',\n",
-       " 'Blood Derived Normal',\n",
-       " 'Bone Marrow Normal',\n",
-       " 'Buccal Cell Normal',\n",
-       " 'Cell Lines',\n",
-       " 'Control Analyte',\n",
-       " 'DNA',\n",
-       " 'Expanded Next Generation Cancer Model',\n",
-       " 'FFPE Scrolls',\n",
-       " 'Fibroblasts from Bone Marrow Normal',\n",
-       " 'Granulocytes',\n",
-       " 'Lymphoid Normal',\n",
-       " 'Metastatic',\n",
-       " 'Mononuclear Cells from Bone Marrow Normal',\n",
-       " 'Neoplasms of Uncertain and Unknown Behavior',\n",
-       " 'Next Generation Cancer Model',\n",
-       " 'Normal',\n",
-       " 'Normal Adjacent Tissue',\n",
-       " 'Not Reported',\n",
-       " 'Post neo-adjuvant therapy',\n",
-       " 'Primary Blood Derived Cancer - Bone Marrow',\n",
-       " 'Primary Blood Derived Cancer - Peripheral Blood',\n",
-       " 'Primary Tumor',\n",
-       " 'Primary Xenograft Tissue',\n",
-       " 'Recurrent Blood Derived Cancer - Bone Marrow',\n",
-       " 'Recurrent Blood Derived Cancer - Peripheral Blood',\n",
-       " 'Recurrent Tumor',\n",
-       " 'Slides',\n",
-       " 'Solid Tissue Normal',\n",
-       " 'Tumor',\n",
-       " 'Unknown',\n",
-       " 'Xenograft',\n",
-       " 'Xenograft Tissue']"
-      ]
+      "text/plain": "['Additional - New Primary',\n 'Additional Metastatic',\n 'Blood Derived Cancer - Bone Marrow',\n 'Blood Derived Cancer - Bone Marrow, Post-treatment',\n 'Blood Derived Cancer - Peripheral Blood',\n 'Blood Derived Cancer - Peripheral Blood, Post-treatment',\n 'Blood Derived Normal',\n 'Bone Marrow Normal',\n 'Buccal Cell Normal',\n 'Cell Lines',\n 'Control Analyte',\n 'DNA',\n 'Expanded Next Generation Cancer Model',\n 'FFPE Scrolls',\n 'Fibroblasts from Bone Marrow Normal',\n 'Granulocytes',\n 'Lymphoid Normal',\n 'Metastatic',\n 'Mononuclear Cells from Bone Marrow Normal',\n 'Neoplasms of Uncertain and Unknown Behavior',\n 'Next Generation Cancer Model',\n 'Normal',\n 'Normal Adjacent Tissue',\n 'Not Reported',\n 'Post neo-adjuvant therapy',\n 'Primary Blood Derived Cancer - Bone Marrow',\n 'Primary Blood Derived Cancer - Peripheral Blood',\n 'Primary Tumor',\n 'Primary Xenograft Tissue',\n 'Recurrent Blood Derived Cancer - Bone Marrow',\n 'Recurrent Blood Derived Cancer - Peripheral Blood',\n 'Recurrent Tumor',\n 'Slides',\n 'Solid Tissue Normal',\n 'Tumor',\n 'Unknown',\n 'Xenograft',\n 'Xenograft Tissue']"
      },
      "execution_count": 3,
      "metadata": {},
@@ -226,17 +136,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['Cell Lines',\n",
-       " 'Normal',\n",
-       " 'Normal Adjacent Tissue',\n",
-       " 'Not Reported',\n",
-       " 'Primary Tumor',\n",
-       " 'Solid Tissue Normal',\n",
-       " 'Tumor',\n",
-       " 'Xenograft',\n",
-       " 'Xenograft Tissue']"
-      ]
+      "text/plain": "['Cell Lines',\n 'Normal',\n 'Normal Adjacent Tissue',\n 'Not Reported',\n 'Primary Tumor',\n 'Solid Tissue Normal',\n 'Tumor',\n 'Xenograft',\n 'Xenograft Tissue']"
      },
      "execution_count": 4,
      "metadata": {},
@@ -268,11 +168,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3 WHERE (v3.id = 'TCGA-E2-A10A')\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3 WHERE (v3.id = 'TCGA-E2-A10A')\n",
       "Offset: 0\n",
-      "Limit: 1000\n",
       "Count: 1\n",
-      "More pages: No\n",
+      "Total Row Count: 1\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -387,11 +287,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Diagnosis.age_at_diagnosis > 50*365) AND (_ResearchSubject.associated_project = 'TCGA-OV'))\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Diagnosis.age_at_diagnosis > 50*365) AND (_ResearchSubject.associated_project = 'TCGA-OV'))\n",
       "Offset: 0\n",
-      "Limit: 1000\n",
       "Count: 461\n",
-      "More pages: No\n",
+      "Total Row Count: 461\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -427,11 +327,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND (_Diagnosis.age_at_diagnosis < 30*365))\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND (_Diagnosis.age_at_diagnosis < 30*365))\n",
       "Offset: 0\n",
-      "Limit: 1000\n",
       "Count: 647\n",
-      "More pages: No\n",
+      "Total Row Count: 647\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -465,11 +365,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis, UNNEST(_Specimen.identifier) AS _identifier WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND ((_Diagnosis.age_at_diagnosis < 30*365) AND (_identifier.system = 'GDC')))\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis, UNNEST(_Specimen.identifier) AS _identifier WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND ((_Diagnosis.age_at_diagnosis < 30*365) AND (_identifier.system = 'GDC')))\n",
       "Offset: 0\n",
-      "Limit: 1000\n",
       "Count: 647\n",
-      "More pages: No\n",
+      "Total Row Count: 647\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -553,11 +453,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
       "Offset: 0\n",
-      "Limit: 1000\n",
-      "Count: 1000\n",
-      "More pages: Yes\n",
+      "Count: 10\n",
+      "Total Row Count: 27284\n",
+      "More pages: True\n",
       "\n"
      ]
     }
@@ -573,7 +473,7 @@
     "q2 = disease1.Or(disease2)\n",
     "q = q1.And(q2)\n",
     "\n",
-    "r = q.run()\n",
+    "r = q.run(limit=10)\n",
     "print(r)"
    ]
   },
@@ -582,7 +482,7 @@
    "id": "marine-failing",
    "metadata": {},
    "source": [
-    "In this case, we have a result that contains more than 1000 records which is the limit for a single page. To load the next 1000 records, we can use the ```next_page()``` method:"
+    "In this case, we have a result that contains more than 1000 records which is the default page size. To load the next 1000 records, we can use the ```next_page()``` method:"
    ]
   },
   {
@@ -606,11 +506,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
-      "Offset: 1000\n",
-      "Limit: 1000\n",
-      "Count: 1000\n",
-      "More pages: Yes\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
+      "Offset: 10\n",
+      "Count: 10\n",
+      "Total Row Count: 27284\n",
+      "More pages: True\n",
       "\n"
      ]
     }
@@ -666,67 +566,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "[None,\n",
-       " 'Acinar Cell Neoplasms',\n",
-       " 'Adenomas and Adenocarcinomas',\n",
-       " 'Adnexal and Skin Appendage Neoplasms',\n",
-       " 'Basal Cell Neoplasms',\n",
-       " 'Blood Vessel Tumors',\n",
-       " 'Chronic Myeloproliferative Disorders',\n",
-       " 'Complex Epithelial Neoplasms',\n",
-       " 'Complex Mixed and Stromal Neoplasms',\n",
-       " 'Cystic, Mucinous and Serous Neoplasms',\n",
-       " 'Ductal and Lobular Neoplasms',\n",
-       " 'Epithelial Neoplasms, NOS',\n",
-       " 'Fibroepithelial Neoplasms',\n",
-       " 'Fibromatous Neoplasms',\n",
-       " 'Germ Cell Neoplasms',\n",
-       " 'Giant Cell Tumors',\n",
-       " 'Gliomas',\n",
-       " 'Granular Cell Tumors and Alveolar Soft Part Sarcomas',\n",
-       " 'Hodgkin Lymphoma',\n",
-       " 'Immunoproliferative Diseases',\n",
-       " 'Leukemias, NOS',\n",
-       " 'Lipomatous Neoplasms',\n",
-       " 'Lymphatic Vessel Tumors',\n",
-       " 'Lymphoid Leukemias',\n",
-       " 'Malignant Lymphomas, NOS or Diffuse',\n",
-       " 'Mast Cell Tumors',\n",
-       " 'Mature B-Cell Lymphomas',\n",
-       " 'Mature T- and NK-Cell Lymphomas',\n",
-       " 'Meningiomas',\n",
-       " 'Mesonephromas',\n",
-       " 'Mesothelial Neoplasms',\n",
-       " 'Miscellaneous Bone Tumors',\n",
-       " 'Miscellaneous Tumors',\n",
-       " 'Mucoepidermoid Neoplasms',\n",
-       " 'Myelodysplastic Syndromes',\n",
-       " 'Myeloid Leukemias',\n",
-       " 'Myomatous Neoplasms',\n",
-       " 'Myxomatous Neoplasms',\n",
-       " 'Neoplasms of Histiocytes and Accessory Lymphoid Cells',\n",
-       " 'Neoplasms, NOS',\n",
-       " 'Nerve Sheath Tumors',\n",
-       " 'Neuroepitheliomatous Neoplasms',\n",
-       " 'Nevi and Melanomas',\n",
-       " 'Not Applicable',\n",
-       " 'Not Reported',\n",
-       " 'Odontogenic Tumors',\n",
-       " 'Osseous and Chondromatous Neoplasms',\n",
-       " 'Other Leukemias',\n",
-       " 'Paragangliomas and Glomus Tumors',\n",
-       " 'Plasma Cell Tumors',\n",
-       " 'Precursor Cell Lymphoblastic Lymphoma',\n",
-       " 'Soft Tissue Tumors and Sarcomas, NOS',\n",
-       " 'Specialized Gonadal Neoplasms',\n",
-       " 'Squamous Cell Neoplasms',\n",
-       " 'Synovial-like Neoplasms',\n",
-       " 'Thymic Epithelial Neoplasms',\n",
-       " 'Transitional Cell Papillomas and Carcinomas',\n",
-       " 'Trophoblastic neoplasms',\n",
-       " 'Unknown']"
-      ]
+      "text/plain": "[None,\n 'Acinar Cell Neoplasms',\n 'Adenomas and Adenocarcinomas',\n 'Adnexal and Skin Appendage Neoplasms',\n 'Basal Cell Neoplasms',\n 'Blood Vessel Tumors',\n 'Chronic Myeloproliferative Disorders',\n 'Complex Epithelial Neoplasms',\n 'Complex Mixed and Stromal Neoplasms',\n 'Cystic, Mucinous and Serous Neoplasms',\n 'Ductal and Lobular Neoplasms',\n 'Epithelial Neoplasms, NOS',\n 'Fibroepithelial Neoplasms',\n 'Fibromatous Neoplasms',\n 'Germ Cell Neoplasms',\n 'Giant Cell Tumors',\n 'Gliomas',\n 'Granular Cell Tumors and Alveolar Soft Part Sarcomas',\n 'Hodgkin Lymphoma',\n 'Immunoproliferative Diseases',\n 'Leukemias, NOS',\n 'Lipomatous Neoplasms',\n 'Lymphatic Vessel Tumors',\n 'Lymphoid Leukemias',\n 'Malignant Lymphomas, NOS or Diffuse',\n 'Mast Cell Tumors',\n 'Mature B-Cell Lymphomas',\n 'Mature T- and NK-Cell Lymphomas',\n 'Meningiomas',\n 'Mesonephromas',\n 'Mesothelial Neoplasms',\n 'Miscellaneous Bone Tumors',\n 'Miscellaneous Tumors',\n 'Mucoepidermoid Neoplasms',\n 'Myelodysplastic Syndromes',\n 'Myeloid Leukemias',\n 'Myomatous Neoplasms',\n 'Myxomatous Neoplasms',\n 'Neoplasms of Histiocytes and Accessory Lymphoid Cells',\n 'Neoplasms, NOS',\n 'Nerve Sheath Tumors',\n 'Neuroepitheliomatous Neoplasms',\n 'Nevi and Melanomas',\n 'Not Applicable',\n 'Not Reported',\n 'Odontogenic Tumors',\n 'Osseous and Chondromatous Neoplasms',\n 'Other Leukemias',\n 'Paragangliomas and Glomus Tumors',\n 'Plasma Cell Tumors',\n 'Precursor Cell Lymphoblastic Lymphoma',\n 'Soft Tissue Tumors and Sarcomas, NOS',\n 'Specialized Gonadal Neoplasms',\n 'Squamous Cell Neoplasms',\n 'Synovial-like Neoplasms',\n 'Thymic Epithelial Neoplasms',\n 'Transitional Cell Papillomas and Carcinomas',\n 'Trophoblastic neoplasms',\n 'Unknown']"
      },
      "execution_count": 15,
      "metadata": {},
@@ -760,26 +600,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['Breast Invasive Carcinoma',\n",
-       " 'Chromophobe Renal Cell Carcinoma',\n",
-       " 'Clear Cell Renal Cell Carcinoma',\n",
-       " 'Colon Adenocarcinoma',\n",
-       " 'Early Onset Gastric Cancer',\n",
-       " 'Glioblastoma',\n",
-       " 'Head and Neck Squamous Cell Carcinoma',\n",
-       " 'Hepatocellular Carcinoma ',\n",
-       " 'Lung Adenocarcinoma',\n",
-       " 'Lung Squamous Cell Carcinoma',\n",
-       " 'Oral Squamous Cell Carcinoma',\n",
-       " 'Other',\n",
-       " 'Ovarian Serous Cystadenocarcinoma',\n",
-       " 'Pancreatic Ductal Adenocarcinoma',\n",
-       " 'Papillary Renal Cell Carcinoma',\n",
-       " 'Pediatric/AYA Brain Tumors',\n",
-       " 'Rectum Adenocarcinoma',\n",
-       " 'Uterine Corpus Endometrial Carcinoma']"
-      ]
+      "text/plain": "['Breast Invasive Carcinoma',\n 'Chromophobe Renal Cell Carcinoma',\n 'Clear Cell Renal Cell Carcinoma',\n 'Colon Adenocarcinoma',\n 'Early Onset Gastric Cancer',\n 'Glioblastoma',\n 'Head and Neck Squamous Cell Carcinoma',\n 'Hepatocellular Carcinoma ',\n 'Lung Adenocarcinoma',\n 'Lung Squamous Cell Carcinoma',\n 'Oral Squamous Cell Carcinoma',\n 'Other',\n 'Ovarian Serous Cystadenocarcinoma',\n 'Pancreatic Ductal Adenocarcinoma',\n 'Papillary Renal Cell Carcinoma',\n 'Pediatric/AYA Brain Tumors',\n 'Rectum Adenocarcinoma',\n 'Uterine Corpus Endometrial Carcinoma']"
      },
      "execution_count": 16,
      "metadata": {},
@@ -809,11 +630,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM (SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE ((_ResearchSubject.primary_disease_type = 'Ovarian Serous Cystadenocarcinoma') AND (_identifier.system = 'PDC'))), UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE (_identifier.system = 'GDC')\n",
+      "Query: SELECT v3.* FROM (SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE ((_ResearchSubject.primary_disease_type = 'Ovarian Serous Cystadenocarcinoma') AND (_identifier.system = 'PDC'))) AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE (_identifier.system = 'GDC')\n",
       "Offset: 0\n",
-      "Limit: 1000\n",
       "Count: 275\n",
-      "More pages: No\n",
+      "Total Row Count: 275\n",
+      "More pages: False\n",
       "\n"
      ]
     }

--- a/example.ipynb
+++ b/example.ipynb
@@ -60,58 +60,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['days_to_birth',\n",
-       " 'race',\n",
-       " 'sex',\n",
-       " 'ethnicity',\n",
-       " 'id',\n",
-       " 'ResearchSubject',\n",
-       " 'ResearchSubject.Diagnosis',\n",
-       " 'ResearchSubject.Diagnosis.morphology',\n",
-       " 'ResearchSubject.Diagnosis.tumor_stage',\n",
-       " 'ResearchSubject.Diagnosis.tumor_grade',\n",
-       " 'ResearchSubject.Diagnosis.Treatment',\n",
-       " 'ResearchSubject.Diagnosis.Treatment.type',\n",
-       " 'ResearchSubject.Diagnosis.Treatment.outcome',\n",
-       " 'ResearchSubject.Diagnosis.id',\n",
-       " 'ResearchSubject.Diagnosis.primary_diagnosis',\n",
-       " 'ResearchSubject.Diagnosis.age_at_diagnosis',\n",
-       " 'ResearchSubject.Specimen',\n",
-       " 'ResearchSubject.Specimen.File',\n",
-       " 'ResearchSubject.Specimen.File.label',\n",
-       " 'ResearchSubject.Specimen.File.associated_project',\n",
-       " 'ResearchSubject.Specimen.File.drs_uri',\n",
-       " 'ResearchSubject.Specimen.File.identifier',\n",
-       " 'ResearchSubject.Specimen.File.identifier.system',\n",
-       " 'ResearchSubject.Specimen.File.identifier.value',\n",
-       " 'ResearchSubject.Specimen.File.data_category',\n",
-       " 'ResearchSubject.Specimen.File.byte_size',\n",
-       " 'ResearchSubject.Specimen.File.type',\n",
-       " 'ResearchSubject.Specimen.File.file_format',\n",
-       " 'ResearchSubject.Specimen.File.checksum',\n",
-       " 'ResearchSubject.Specimen.File.id',\n",
-       " 'ResearchSubject.Specimen.File.data_type',\n",
-       " 'ResearchSubject.Specimen.derived_from_specimen',\n",
-       " 'ResearchSubject.Specimen.associated_project',\n",
-       " 'ResearchSubject.Specimen.age_at_collection',\n",
-       " 'ResearchSubject.Specimen.anatomical_site',\n",
-       " 'ResearchSubject.Specimen.source_material_type',\n",
-       " 'ResearchSubject.Specimen.derived_from_subject',\n",
-       " 'ResearchSubject.Specimen.specimen_type',\n",
-       " 'ResearchSubject.Specimen.id',\n",
-       " 'ResearchSubject.Specimen.primary_disease_type',\n",
-       " 'ResearchSubject.Specimen.identifier',\n",
-       " 'ResearchSubject.Specimen.identifier.system',\n",
-       " 'ResearchSubject.Specimen.identifier.value',\n",
-       " 'ResearchSubject.associated_project',\n",
-       " 'ResearchSubject.id',\n",
-       " 'ResearchSubject.primary_disease_type',\n",
-       " 'ResearchSubject.identifier',\n",
-       " 'ResearchSubject.identifier.system',\n",
-       " 'ResearchSubject.identifier.value',\n",
-       " 'ResearchSubject.primary_disease_site']"
-      ]
+      "text/plain": "['days_to_birth',\n 'race',\n 'sex',\n 'ethnicity',\n 'id',\n 'ResearchSubject',\n 'ResearchSubject.Diagnosis',\n 'ResearchSubject.Diagnosis.morphology',\n 'ResearchSubject.Diagnosis.tumor_stage',\n 'ResearchSubject.Diagnosis.tumor_grade',\n 'ResearchSubject.Diagnosis.Treatment',\n 'ResearchSubject.Diagnosis.Treatment.type',\n 'ResearchSubject.Diagnosis.Treatment.outcome',\n 'ResearchSubject.Diagnosis.id',\n 'ResearchSubject.Diagnosis.primary_diagnosis',\n 'ResearchSubject.Diagnosis.age_at_diagnosis',\n 'ResearchSubject.Specimen',\n 'ResearchSubject.Specimen.File',\n 'ResearchSubject.Specimen.File.label',\n 'ResearchSubject.Specimen.File.associated_project',\n 'ResearchSubject.Specimen.File.drs_uri',\n 'ResearchSubject.Specimen.File.identifier',\n 'ResearchSubject.Specimen.File.identifier.system',\n 'ResearchSubject.Specimen.File.identifier.value',\n 'ResearchSubject.Specimen.File.data_category',\n 'ResearchSubject.Specimen.File.byte_size',\n 'ResearchSubject.Specimen.File.type',\n 'ResearchSubject.Specimen.File.file_format',\n 'ResearchSubject.Specimen.File.checksum',\n 'ResearchSubject.Specimen.File.id',\n 'ResearchSubject.Specimen.File.data_type',\n 'ResearchSubject.Specimen.derived_from_specimen',\n 'ResearchSubject.Specimen.associated_project',\n 'ResearchSubject.Specimen.age_at_collection',\n 'ResearchSubject.Specimen.anatomical_site',\n 'ResearchSubject.Specimen.source_material_type',\n 'ResearchSubject.Specimen.derived_from_subject',\n 'ResearchSubject.Specimen.specimen_type',\n 'ResearchSubject.Specimen.id',\n 'ResearchSubject.Specimen.primary_disease_type',\n 'ResearchSubject.Specimen.identifier',\n 'ResearchSubject.Specimen.identifier.system',\n 'ResearchSubject.Specimen.identifier.value',\n 'ResearchSubject.associated_project',\n 'ResearchSubject.id',\n 'ResearchSubject.primary_disease_type',\n 'ResearchSubject.identifier',\n 'ResearchSubject.identifier.system',\n 'ResearchSubject.identifier.value',\n 'ResearchSubject.primary_disease_site']"
      },
      "execution_count": 2,
      "metadata": {},
@@ -153,46 +102,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['Additional - New Primary',\n",
-       " 'Additional Metastatic',\n",
-       " 'Blood Derived Cancer - Bone Marrow',\n",
-       " 'Blood Derived Cancer - Bone Marrow, Post-treatment',\n",
-       " 'Blood Derived Cancer - Peripheral Blood',\n",
-       " 'Blood Derived Cancer - Peripheral Blood, Post-treatment',\n",
-       " 'Blood Derived Normal',\n",
-       " 'Bone Marrow Normal',\n",
-       " 'Buccal Cell Normal',\n",
-       " 'Cell Lines',\n",
-       " 'Control Analyte',\n",
-       " 'DNA',\n",
-       " 'Expanded Next Generation Cancer Model',\n",
-       " 'FFPE Scrolls',\n",
-       " 'Fibroblasts from Bone Marrow Normal',\n",
-       " 'Granulocytes',\n",
-       " 'Lymphoid Normal',\n",
-       " 'Metastatic',\n",
-       " 'Mononuclear Cells from Bone Marrow Normal',\n",
-       " 'Neoplasms of Uncertain and Unknown Behavior',\n",
-       " 'Next Generation Cancer Model',\n",
-       " 'Normal',\n",
-       " 'Normal Adjacent Tissue',\n",
-       " 'Not Reported',\n",
-       " 'Post neo-adjuvant therapy',\n",
-       " 'Primary Blood Derived Cancer - Bone Marrow',\n",
-       " 'Primary Blood Derived Cancer - Peripheral Blood',\n",
-       " 'Primary Tumor',\n",
-       " 'Primary Xenograft Tissue',\n",
-       " 'Recurrent Blood Derived Cancer - Bone Marrow',\n",
-       " 'Recurrent Blood Derived Cancer - Peripheral Blood',\n",
-       " 'Recurrent Tumor',\n",
-       " 'Slides',\n",
-       " 'Solid Tissue Normal',\n",
-       " 'Tumor',\n",
-       " 'Unknown',\n",
-       " 'Xenograft',\n",
-       " 'Xenograft Tissue']"
-      ]
+      "text/plain": "['Additional - New Primary',\n 'Additional Metastatic',\n 'Blood Derived Cancer - Bone Marrow',\n 'Blood Derived Cancer - Bone Marrow, Post-treatment',\n 'Blood Derived Cancer - Peripheral Blood',\n 'Blood Derived Cancer - Peripheral Blood, Post-treatment',\n 'Blood Derived Normal',\n 'Bone Marrow Normal',\n 'Buccal Cell Normal',\n 'Cell Lines',\n 'Control Analyte',\n 'DNA',\n 'Expanded Next Generation Cancer Model',\n 'FFPE Scrolls',\n 'Fibroblasts from Bone Marrow Normal',\n 'Granulocytes',\n 'Lymphoid Normal',\n 'Metastatic',\n 'Mononuclear Cells from Bone Marrow Normal',\n 'Neoplasms of Uncertain and Unknown Behavior',\n 'Next Generation Cancer Model',\n 'Normal',\n 'Normal Adjacent Tissue',\n 'Not Reported',\n 'Post neo-adjuvant therapy',\n 'Primary Blood Derived Cancer - Bone Marrow',\n 'Primary Blood Derived Cancer - Peripheral Blood',\n 'Primary Tumor',\n 'Primary Xenograft Tissue',\n 'Recurrent Blood Derived Cancer - Bone Marrow',\n 'Recurrent Blood Derived Cancer - Peripheral Blood',\n 'Recurrent Tumor',\n 'Slides',\n 'Solid Tissue Normal',\n 'Tumor',\n 'Unknown',\n 'Xenograft',\n 'Xenograft Tissue']"
      },
      "execution_count": 3,
      "metadata": {},
@@ -226,17 +136,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['Cell Lines',\n",
-       " 'Normal',\n",
-       " 'Normal Adjacent Tissue',\n",
-       " 'Not Reported',\n",
-       " 'Primary Tumor',\n",
-       " 'Solid Tissue Normal',\n",
-       " 'Tumor',\n",
-       " 'Xenograft',\n",
-       " 'Xenograft Tissue']"
-      ]
+      "text/plain": "['Cell Lines',\n 'Normal',\n 'Normal Adjacent Tissue',\n 'Not Reported',\n 'Primary Tumor',\n 'Solid Tissue Normal',\n 'Tumor',\n 'Xenograft',\n 'Xenograft Tissue']"
      },
      "execution_count": 4,
      "metadata": {},
@@ -268,11 +168,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3 WHERE (v3.id = 'TCGA-E2-A10A')\n",
-      "Offset: 0\n",
-      "Limit: 1000\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3 WHERE (v3.id = 'TCGA-E2-A10A')\n",
       "Count: 1\n",
-      "More pages: No\n",
+      "Total Row Count: 1\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -387,11 +286,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Diagnosis.age_at_diagnosis > 50*365) AND (_ResearchSubject.associated_project = 'TCGA-OV'))\n",
-      "Offset: 0\n",
-      "Limit: 1000\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Diagnosis.age_at_diagnosis > 50*365) AND (_ResearchSubject.associated_project = 'TCGA-OV'))\n",
       "Count: 461\n",
-      "More pages: No\n",
+      "Total Row Count: 461\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -427,11 +325,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND (_Diagnosis.age_at_diagnosis < 30*365))\n",
-      "Offset: 0\n",
-      "Limit: 1000\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND (_Diagnosis.age_at_diagnosis < 30*365))\n",
       "Count: 647\n",
-      "More pages: No\n",
+      "Total Row Count: 647\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -465,11 +362,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis, UNNEST(_Specimen.identifier) AS _identifier WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND ((_Diagnosis.age_at_diagnosis < 30*365) AND (_identifier.system = 'GDC')))\n",
-      "Offset: 0\n",
-      "Limit: 1000\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen, UNNEST(_ResearchSubject.Diagnosis) AS _Diagnosis, UNNEST(_Specimen.identifier) AS _identifier WHERE ((_Specimen.primary_disease_type = 'Nevi and Melanomas') AND ((_Diagnosis.age_at_diagnosis < 30*365) AND (_identifier.system = 'GDC')))\n",
       "Count: 647\n",
-      "More pages: No\n",
+      "Total Row Count: 647\n",
+      "More pages: False\n",
       "\n"
      ]
     }
@@ -505,7 +401,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'TCGA-UVM', 'TCGA-SKCM', 'FM-AD'}\n"
+      "{'FM-AD', 'TCGA-SKCM', 'TCGA-UVM'}\n"
      ]
     }
    ],
@@ -553,11 +449,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
-      "Offset: 0\n",
-      "Limit: 1000\n",
-      "Count: 1000\n",
-      "More pages: Yes\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
+      "Count: 10\n",
+      "Total Row Count: 27284\n",
+      "More pages: True\n",
       "\n"
      ]
     }
@@ -573,7 +468,7 @@
     "q2 = disease1.Or(disease2)\n",
     "q = q1.And(q2)\n",
     "\n",
-    "r = q.run()\n",
+    "r = q.run(limit=10)\n",
     "print(r)"
    ]
   },
@@ -582,7 +477,7 @@
    "id": "marine-failing",
    "metadata": {},
    "source": [
-    "In this case, we have a result that contains more than 1000 records which is the limit for a single page. To load the next 1000 records, we can use the ```next_page()``` method:"
+    "In this case, we have a result that contains more than 1000 records which is the default page size. To load the next 1000 records, we can use the ```next_page()``` method:"
    ]
   },
   {
@@ -606,11 +501,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
-      "Offset: 1000\n",
-      "Limit: 1000\n",
-      "Count: 1000\n",
-      "More pages: Yes\n",
+      "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
+      "Count: 10\n",
+      "Total Row Count: 27284\n",
+      "More pages: True\n",
       "\n"
      ]
     }
@@ -666,67 +560,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "[None,\n",
-       " 'Acinar Cell Neoplasms',\n",
-       " 'Adenomas and Adenocarcinomas',\n",
-       " 'Adnexal and Skin Appendage Neoplasms',\n",
-       " 'Basal Cell Neoplasms',\n",
-       " 'Blood Vessel Tumors',\n",
-       " 'Chronic Myeloproliferative Disorders',\n",
-       " 'Complex Epithelial Neoplasms',\n",
-       " 'Complex Mixed and Stromal Neoplasms',\n",
-       " 'Cystic, Mucinous and Serous Neoplasms',\n",
-       " 'Ductal and Lobular Neoplasms',\n",
-       " 'Epithelial Neoplasms, NOS',\n",
-       " 'Fibroepithelial Neoplasms',\n",
-       " 'Fibromatous Neoplasms',\n",
-       " 'Germ Cell Neoplasms',\n",
-       " 'Giant Cell Tumors',\n",
-       " 'Gliomas',\n",
-       " 'Granular Cell Tumors and Alveolar Soft Part Sarcomas',\n",
-       " 'Hodgkin Lymphoma',\n",
-       " 'Immunoproliferative Diseases',\n",
-       " 'Leukemias, NOS',\n",
-       " 'Lipomatous Neoplasms',\n",
-       " 'Lymphatic Vessel Tumors',\n",
-       " 'Lymphoid Leukemias',\n",
-       " 'Malignant Lymphomas, NOS or Diffuse',\n",
-       " 'Mast Cell Tumors',\n",
-       " 'Mature B-Cell Lymphomas',\n",
-       " 'Mature T- and NK-Cell Lymphomas',\n",
-       " 'Meningiomas',\n",
-       " 'Mesonephromas',\n",
-       " 'Mesothelial Neoplasms',\n",
-       " 'Miscellaneous Bone Tumors',\n",
-       " 'Miscellaneous Tumors',\n",
-       " 'Mucoepidermoid Neoplasms',\n",
-       " 'Myelodysplastic Syndromes',\n",
-       " 'Myeloid Leukemias',\n",
-       " 'Myomatous Neoplasms',\n",
-       " 'Myxomatous Neoplasms',\n",
-       " 'Neoplasms of Histiocytes and Accessory Lymphoid Cells',\n",
-       " 'Neoplasms, NOS',\n",
-       " 'Nerve Sheath Tumors',\n",
-       " 'Neuroepitheliomatous Neoplasms',\n",
-       " 'Nevi and Melanomas',\n",
-       " 'Not Applicable',\n",
-       " 'Not Reported',\n",
-       " 'Odontogenic Tumors',\n",
-       " 'Osseous and Chondromatous Neoplasms',\n",
-       " 'Other Leukemias',\n",
-       " 'Paragangliomas and Glomus Tumors',\n",
-       " 'Plasma Cell Tumors',\n",
-       " 'Precursor Cell Lymphoblastic Lymphoma',\n",
-       " 'Soft Tissue Tumors and Sarcomas, NOS',\n",
-       " 'Specialized Gonadal Neoplasms',\n",
-       " 'Squamous Cell Neoplasms',\n",
-       " 'Synovial-like Neoplasms',\n",
-       " 'Thymic Epithelial Neoplasms',\n",
-       " 'Transitional Cell Papillomas and Carcinomas',\n",
-       " 'Trophoblastic neoplasms',\n",
-       " 'Unknown']"
-      ]
+      "text/plain": "[None,\n 'Acinar Cell Neoplasms',\n 'Adenomas and Adenocarcinomas',\n 'Adnexal and Skin Appendage Neoplasms',\n 'Basal Cell Neoplasms',\n 'Blood Vessel Tumors',\n 'Chronic Myeloproliferative Disorders',\n 'Complex Epithelial Neoplasms',\n 'Complex Mixed and Stromal Neoplasms',\n 'Cystic, Mucinous and Serous Neoplasms',\n 'Ductal and Lobular Neoplasms',\n 'Epithelial Neoplasms, NOS',\n 'Fibroepithelial Neoplasms',\n 'Fibromatous Neoplasms',\n 'Germ Cell Neoplasms',\n 'Giant Cell Tumors',\n 'Gliomas',\n 'Granular Cell Tumors and Alveolar Soft Part Sarcomas',\n 'Hodgkin Lymphoma',\n 'Immunoproliferative Diseases',\n 'Leukemias, NOS',\n 'Lipomatous Neoplasms',\n 'Lymphatic Vessel Tumors',\n 'Lymphoid Leukemias',\n 'Malignant Lymphomas, NOS or Diffuse',\n 'Mast Cell Tumors',\n 'Mature B-Cell Lymphomas',\n 'Mature T- and NK-Cell Lymphomas',\n 'Meningiomas',\n 'Mesonephromas',\n 'Mesothelial Neoplasms',\n 'Miscellaneous Bone Tumors',\n 'Miscellaneous Tumors',\n 'Mucoepidermoid Neoplasms',\n 'Myelodysplastic Syndromes',\n 'Myeloid Leukemias',\n 'Myomatous Neoplasms',\n 'Myxomatous Neoplasms',\n 'Neoplasms of Histiocytes and Accessory Lymphoid Cells',\n 'Neoplasms, NOS',\n 'Nerve Sheath Tumors',\n 'Neuroepitheliomatous Neoplasms',\n 'Nevi and Melanomas',\n 'Not Applicable',\n 'Not Reported',\n 'Odontogenic Tumors',\n 'Osseous and Chondromatous Neoplasms',\n 'Other Leukemias',\n 'Paragangliomas and Glomus Tumors',\n 'Plasma Cell Tumors',\n 'Precursor Cell Lymphoblastic Lymphoma',\n 'Soft Tissue Tumors and Sarcomas, NOS',\n 'Specialized Gonadal Neoplasms',\n 'Squamous Cell Neoplasms',\n 'Synovial-like Neoplasms',\n 'Thymic Epithelial Neoplasms',\n 'Transitional Cell Papillomas and Carcinomas',\n 'Trophoblastic neoplasms',\n 'Unknown']"
      },
      "execution_count": 15,
      "metadata": {},
@@ -760,26 +594,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "['Breast Invasive Carcinoma',\n",
-       " 'Chromophobe Renal Cell Carcinoma',\n",
-       " 'Clear Cell Renal Cell Carcinoma',\n",
-       " 'Colon Adenocarcinoma',\n",
-       " 'Early Onset Gastric Cancer',\n",
-       " 'Glioblastoma',\n",
-       " 'Head and Neck Squamous Cell Carcinoma',\n",
-       " 'Hepatocellular Carcinoma ',\n",
-       " 'Lung Adenocarcinoma',\n",
-       " 'Lung Squamous Cell Carcinoma',\n",
-       " 'Oral Squamous Cell Carcinoma',\n",
-       " 'Other',\n",
-       " 'Ovarian Serous Cystadenocarcinoma',\n",
-       " 'Pancreatic Ductal Adenocarcinoma',\n",
-       " 'Papillary Renal Cell Carcinoma',\n",
-       " 'Pediatric/AYA Brain Tumors',\n",
-       " 'Rectum Adenocarcinoma',\n",
-       " 'Uterine Corpus Endometrial Carcinoma']"
-      ]
+      "text/plain": "['Breast Invasive Carcinoma',\n 'Chromophobe Renal Cell Carcinoma',\n 'Clear Cell Renal Cell Carcinoma',\n 'Colon Adenocarcinoma',\n 'Early Onset Gastric Cancer',\n 'Glioblastoma',\n 'Head and Neck Squamous Cell Carcinoma',\n 'Hepatocellular Carcinoma ',\n 'Lung Adenocarcinoma',\n 'Lung Squamous Cell Carcinoma',\n 'Oral Squamous Cell Carcinoma',\n 'Other',\n 'Ovarian Serous Cystadenocarcinoma',\n 'Pancreatic Ductal Adenocarcinoma',\n 'Papillary Renal Cell Carcinoma',\n 'Pediatric/AYA Brain Tumors',\n 'Rectum Adenocarcinoma',\n 'Uterine Corpus Endometrial Carcinoma']"
      },
      "execution_count": 16,
      "metadata": {},
@@ -809,11 +624,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Query: SELECT * FROM (SELECT * FROM gdc-bq-sample.cda_mvp.v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE ((_ResearchSubject.primary_disease_type = 'Ovarian Serous Cystadenocarcinoma') AND (_identifier.system = 'PDC'))), UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE (_identifier.system = 'GDC')\n",
-      "Offset: 0\n",
-      "Limit: 1000\n",
+      "Query: SELECT v3.* FROM (SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE ((_ResearchSubject.primary_disease_type = 'Ovarian Serous Cystadenocarcinoma') AND (_identifier.system = 'PDC'))) AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.identifier) AS _identifier WHERE (_identifier.system = 'GDC')\n",
       "Count: 275\n",
-      "More pages: No\n",
+      "Total Row Count: 275\n",
+      "More pages: False\n",
       "\n"
      ]
     }

--- a/example.ipynb
+++ b/example.ipynb
@@ -455,7 +455,7 @@
       "\n",
       "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
       "Offset: 0\n",
-      "Count: 10\n",
+      "Count: 1000\n",
       "Total Row Count: 27284\n",
       "More pages: True\n",
       "\n"
@@ -473,7 +473,7 @@
     "q2 = disease1.Or(disease2)\n",
     "q = q1.And(q2)\n",
     "\n",
-    "r = q.run(limit=10)\n",
+    "r = q.run()\n",
     "print(r)"
    ]
   },
@@ -507,8 +507,8 @@
      "text": [
       "\n",
       "Query: SELECT v3.* FROM gdc-bq-sample.cda_mvp.v3 AS v3, UNNEST(ResearchSubject) AS _ResearchSubject, UNNEST(_ResearchSubject.Specimen) AS _Specimen WHERE (((_Specimen.source_material_type = 'Primary Tumor') AND ((v3.sex = 'female') AND (v3.days_to_birth > -60*365))) AND ((_ResearchSubject.primary_disease_site = 'Ovary') OR (_ResearchSubject.primary_disease_site = 'Breast')))\n",
-      "Offset: 10\n",
-      "Count: 10\n",
+      "Offset: 1000\n",
+      "Count: 1000\n",
       "Total Row Count: 27284\n",
       "More pages: True\n",
       "\n"


### PR DESCRIPTION
This adds support for the new asynchronous query APIs. The cda-python wrapper hides the async queries so there are (almost) no changes to the python API.

New fields in `Result`:
- `Result.total_row_count` is the total number of rows in the query response
- `Result.has_next_page` is true if there are more rows of data

The API now makes a distinction between `limit` and `page_size`. `limit` is the limit of total rows in the query response. If this is not provided, there is no limit and all rows will be generated. `page_size` is the number of rows in a page of data. This is the one API change which could affect users. In most cases users will want to omit `limit` and use `page_size` where they used to use `limit`.

Requires cda-client v1.1.0

Fixes #11