### PR TITLE
Bugfix/issue 27 sql version remove

### DIFF
--- a/cdapython.py
+++ b/cdapython.py
@@ -8,7 +8,8 @@ from cda_client.model.query import Query
 
 __version__ = "2021.5.14"
 
-CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
+#CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
+CDA_API_URL = "http://localhost:8080"
 table_version = "v3"
 
 pp = pprint.PrettyPrinter(indent=2)
@@ -149,14 +150,14 @@ More pages: {self.has_next_page}
 
 def columns(version=table_version, host=CDA_API_URL):
     """Get columns names from the database."""
-    query = f"SELECT field_path FROM `gdc-bq-sample.cda_mvp.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name = '{version}'"
+    query = f"SELECT field_path FROM `gdc-bq-sample.cda_mvp.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`"
     sys.stderr.write(f"{query}\n")
     # Execute query
     with cda_client.ApiClient(
             configuration=cda_client.Configuration(host=host)
     ) as api_client:
         api_instance = QueryApi(api_client)
-        api_response = api_instance.sql_query(query, version=version)
+        api_response = api_instance.sql_query(query)
         query_result = get_query_result(api_instance, api_response.query_id, 0, 1000)
         return [list(t.values())[0] for t in query_result]
 
@@ -186,7 +187,7 @@ def unique_terms(col_name, system=None, version=table_version, host=CDA_API_URL)
         sys.stderr.write(f"{query}\n")
 
         # Execute query
-        api_response = api_instance.sql_query(query, version=version)
+        api_response = api_instance.sql_query(query)
         query_result = get_query_result(api_instance, api_response.query_id, 0, 1000)
         return [list(t.values())[0] for t in query_result]
 

--- a/cdapython.py
+++ b/cdapython.py
@@ -6,10 +6,10 @@ import cda_client
 from cda_client.api.query_api import QueryApi
 from cda_client.model.query import Query
 
-__version__ = "2021.5.14"
+__version__ = "2021.6.15"
 
-#CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
-CDA_API_URL = "http://localhost:8080"
+CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
+
 table_version = "v3"
 
 pp = pprint.PrettyPrinter(indent=2)

--- a/cdapython.py
+++ b/cdapython.py
@@ -8,8 +8,7 @@ from cda_client.model.query import Query
 
 __version__ = "2021.6.15"
 
-#CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
-CDA_API_URL = "http://localhost:8080"
+CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
 table_version = "v3"
 
 pp = pprint.PrettyPrinter(indent=2)

--- a/cdapython.py
+++ b/cdapython.py
@@ -8,8 +8,8 @@ from cda_client.model.query import Query
 
 __version__ = "2021.6.15"
 
-CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
-
+#CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
+CDA_API_URL = "http://localhost:8080"
 table_version = "v3"
 
 pp = pprint.PrettyPrinter(indent=2)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import pathlib
-import requests
 from datetime import datetime
 from setuptools import setup, find_packages
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import pathlib
 from datetime import datetime
 from setuptools import setup, find_packages
 
-__version__ = "2021.2.23"
+__version__ = "2021.6.15"
 current_path = pathlib.Path(__file__).parent
 
 name = "cdapython"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import pathlib
+import requests
 from datetime import datetime
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
This fixes a breaking inconsistency caused when removing the version attribute from the sql-query in cda-service.
This release must be used with the **cda-service (master) branch**