### PR TITLE
Bugfix/issue26 support system in uniq values

### DIFF
--- a/cdapython.py
+++ b/cdapython.py
@@ -8,7 +8,8 @@ from cda_client.model.query import Query
 
 __version__ = "2021.6.15"
 
-CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
+#CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
+CDA_API_URL = "http://localhost:8080"
 table_version = "v3"
 
 pp = pprint.PrettyPrinter(indent=2)
@@ -166,27 +167,9 @@ def unique_terms(col_name, system=None, version=table_version, host=CDA_API_URL)
             configuration=cda_client.Configuration(host=host)
     ) as api_client:
         api_instance = QueryApi(api_client)
-        _new_col, _unnest_col = _get_unnest_clause(col_name=col_name)
-
-        if system:
-            _new_system, _unnest_system = _get_unnest_clause(col_name='ResearchSubject.identifier.system')
-            _unnest = _unnest_col + [item for item in _unnest_system if item not in _unnest_col]
-            _where_clause = f" WHERE {_new_system}=\"{system}\""
-        else:
-            _unnest = _unnest_col
-            _where_clause = ''
-        if _unnest:
-            _unnest_clause = f", {','.join(_unnest)}"
-        else:
-            _unnest_clause = ''
-
-        query = f"SELECT DISTINCT({_new_col}) FROM `gdc-bq-sample.cda_mvp.{version}`" \
-                f"{_unnest_clause}{_where_clause} ORDER BY {_new_col}"
-
-        sys.stderr.write(f"{query}\n")
 
         # Execute query
-        api_response = api_instance.sql_query(query)
+        api_response = api_instance.unique_values(version=version, body=col_name, system=system)
         query_result = get_query_result(api_instance, api_response.query_id, 0, 1000)
         return [list(t.values())[0] for t in query_result]
 

--- a/cdapython.py
+++ b/cdapython.py
@@ -6,7 +6,7 @@ import cda_client
 from cda_client.api.query_api import QueryApi
 from cda_client.model.query import Query
 
-__version__ = "2021.6.15"
+__version__ = "2021.6.28"
 
 CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
 table_version = "v3"

--- a/cdapython.py
+++ b/cdapython.py
@@ -172,22 +172,3 @@ def unique_terms(col_name, system=None, version=table_version, host=CDA_API_URL)
         query_result = get_query_result(api_instance, api_response.query_id, 0, 1000)
         return [list(t.values())[0] for t in query_result]
 
-
-# column ->
-# SELECT DISTINCT(column)
-
-# D.column ->
-# SELECT DISTINCT(_D.column) FROM TABLE, UNNEST(D) AS _D
-
-# A.B.C.D.column ->
-# SELECT DISTINCT(_D.column) FROM TABLE, UNNEST(A) AS _A, UNNEST(_A.B) AS _B, UNNEST(_B.C) AS _C, UNNEST(_C.D) AS _D
-def _get_unnest_clause(col_name):
-    _new_col, _unnest = col_name, []
-    c = col_name.split(".")
-    if len(c) > 1:
-        _new_col = f"_{c[-2]}.{c[-1]}"
-        _unnest = [f"UNNEST({c[0]}) AS _{c[0]}"]
-        for n in range(1, len(c) - 1):
-            _unnest += [f"UNNEST(_{c[n - 1]}.{c[n]}) AS _{c[n]}"]
-
-    return _new_col, _unnest

--- a/cdapython.py
+++ b/cdapython.py
@@ -8,8 +8,7 @@ from cda_client.model.query import Query
 
 __version__ = "2021.6.15"
 
-#CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
-CDA_API_URL = "http://localhost:8080"
+CDA_API_URL = "https://cda.cda-dev.broadinstitute.org"
 table_version = "v3"
 
 pp = pprint.PrettyPrinter(indent=2)

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "vertical-medium",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "wooden-windsor",
    "metadata": {
     "scrolled": false
@@ -113,7 +113,7 @@
        " 'ResearchSubject.primary_disease_site']"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -930,9 +930,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -944,7 +944,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "vertical-medium",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "wooden-windsor",
    "metadata": {
     "scrolled": false
@@ -113,7 +113,7 @@
        " 'ResearchSubject.primary_disease_site']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -930,9 +930,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
-   "name": "python3"
+   "name": "venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -944,7 +944,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,24 +1,7 @@
-from cdapython import Q, _get_unnest_clause
+from cdapython import Q
 
 
 def test1():
     q1 = Q('Diagnosis.age_at_diagnosis >= 50')
     assert q1.query.node_type == ">="
 
-
-def test_unique():
-    col_name, unnest = _get_unnest_clause("A")
-    assert col_name == "A"
-    assert unnest == []
-
-    col_name, unnest = _get_unnest_clause("A.col")
-    assert col_name == "_A.col"
-    assert unnest == ["UNNEST(A) AS _A"]
-
-    col_name, unnest = _get_unnest_clause("A.B.col")
-    assert col_name == "_B.col"
-    assert unnest == ["UNNEST(A) AS _A", "UNNEST(_A.B) AS _B"]
-
-    col_name, unnest = _get_unnest_clause("A.B.C.col")
-    assert col_name == "_C.col"
-    assert unnest == ["UNNEST(A) AS _A", "UNNEST(_A.B) AS _B", "UNNEST(_B.C) AS _C"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,12 @@
 from cdapython import columns
+from cdapython import unique_terms
 
 
 def test_basic_integration():
     cols = columns()
     assert "race" in cols
+     
+
+def test_unique_terms():
+    terms = unique_terms('sex')
+    assert "female" in terms

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,6 @@ from cdapython import unique_terms
 def test_basic_integration():
     cols = columns()
     assert "race" in cols
-     
 
 def test_unique_terms():
     terms = unique_terms('sex')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,5 +7,5 @@ def test_basic_integration():
     assert "race" in cols
 
 def test_unique_terms():
-    terms = unique_terms('sex')
+    terms = unique_terms('sex', 'GDC')
     assert "female" in terms


### PR DESCRIPTION
This PR removes the native python unique_terms code and simply calls the cda-service API call in it's place.  The optional system attribute has been enabled to match the ability to filter eq. GDC, PDC  